### PR TITLE
add missing semicolon

### DIFF
--- a/setup.iss
+++ b/setup.iss
@@ -64,7 +64,7 @@ begin
       vbox_user_home := vbox_home + '\.VirtualBox'
     else
       vbox_user_home := GetEnv('UserProfile') + '\.VirtualBox';
-  end
+  end;
   SetIniString('Settings', 'VBOX_USER_HOME', vbox_user_home, ExpandConstant('{app}') + '\VBoxVmService.INI');
 end;
 


### PR DESCRIPTION
When I tried to run `do_build.bat` Inno 5.6.1 complained about a missing semicolon in the code section. This PR adds that semicolon in.