### PR TITLE
docs: Fix a few typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ When windows starts up, the wrapper-service will start running. It will check fo
 
 If RunWebService=yes is specified in VBoxVmService.ini file,  the wrapper-service will also try to start VirtualBox web service automatically. This might be useful for people who use the web service a lot, like users of phpVirtualBox.
 
-When windows shuts down, the wrapper-service will try to stop all the VMs configuered in VBoxVmService.ini.
+When windows shuts down, the wrapper-service will try to stop all the VMs configured in VBoxVmService.ini.
 
 VmServiceControl.exe is the CLI (command line interface) client that sends control commands to VBoxVmService and display returned results.
 

--- a/src/VBoxVmPipeManager.cpp
+++ b/src/VBoxVmPipeManager.cpp
@@ -133,7 +133,7 @@ int PipeManager(LPTSTR lpszPipename, void __cdecl GetAnswerToRequest(LPPIPEINST 
             READING_STATE;     // ready to read 
     } 
 
-    // Create an event object used to signal that PipeManager shuld exit. 
+    // Create an event object used to signal that PipeManager should exit. 
     hEvents[INSTANCES] = CreateEvent( 
             NULL,    // default security attribute 
             TRUE,    // manual-reset event 
@@ -283,7 +283,7 @@ int PipeManager(LPTSTR lpszPipename, void __cdecl GetAnswerToRequest(LPPIPEINST 
                 { 
                     Pipe[i].fPendingIO = FALSE; 
                     Pipe[i].dwState = READING_STATE; 
-                    Pipe[i].cbToWrite = 0; //All data is writen
+                    Pipe[i].cbToWrite = 0; //All data is written
                     continue; 
                 } 
 

--- a/src/VBoxVmService.cpp
+++ b/src/VBoxVmService.cpp
@@ -87,7 +87,7 @@ BOOL CtrlHandler( DWORD fdwCtrlType )
         PipeManagerExit();
 
         // wait till all VMs stopped, but we must respond in 20 seconds
-        // in the control hander, use 15 seconds for safety here.
+        // in the control handler, use 15 seconds for safety here.
         if (WaitForSingleObject(ghVMStoppedEvent, 15000) == WAIT_OBJECT_0)
             WriteLog("Received all VM stopped event.");
     }
@@ -154,7 +154,7 @@ char *nIndexToVmName(int nIndex) {
 
 //***********************************************************
 //  Run a console app by calling the pCommandLine.
-//  The stdout is loged to the VBoxVmService.log logfile. 
+//  The stdout is logged to the VBoxVmService.log logfile. 
 //  The process ID of the started process is returned
 //***********************************************************
 
@@ -785,7 +785,7 @@ unsigned __stdcall WorkerProc(void* pParam)
         }
     }
 
-    //PipeManager will handel all pipe connections
+    //PipeManager will handle all pipe connections
     PipeManager("\\\\.\\pipe\\VBoxVmService", WorkerHandleCommand);
 
     //gracefully ending the service

--- a/src/VmServiceControl.cpp
+++ b/src/VmServiceControl.cpp
@@ -431,7 +431,7 @@ void main(int argc, char *argv[] )
     {           
         KillService();
     }
-    // Simulates a shuddown if VBoxVmService is started with -d
+    // Simulates a shutdown if VBoxVmService is started with -d
     else if(argc==2&&_stricmp("-dk",argv[1])==0)
     {           
         if(SendCommandToService("shutdown", chBuf, sizeof(chBuf)))
@@ -459,7 +459,7 @@ void main(int argc, char *argv[] )
     {
         printf("Shutdown option needs to be followed by a VM index.\n");
     }
-    // shutdown a specifc vm (if the index is supplied)
+    // shutdown a specific vm (if the index is supplied)
     else if(argc==3&&_stricmp("-sd",argv[1])==0)
     {
         int nIndex = atoi(argv[2]);
@@ -471,7 +471,7 @@ void main(int argc, char *argv[] )
         int nIndex = atoi(argv[2]);
         VMStatus(nIndex);
     }
-    // list all configed VMs' status if switch is "-l"
+    // list all configured VMs' status if switch is "-l"
     else if(argc==2&&_stricmp("-l",argv[1])==0)
     {           
         ListVMs();


### PR DESCRIPTION
There are small typos in:
- README.md
- src/VBoxVmPipeManager.cpp
- src/VBoxVmService.cpp
- src/VmServiceControl.cpp

Fixes:
- Should read `written` rather than `writen`.
- Should read `specific` rather than `specifc`.
- Should read `shutdown` rather than `shuddown`.
- Should read `should` rather than `shuld`.
- Should read `logged` rather than `loged`.
- Should read `handler` rather than `hander`.
- Should read `handle` rather than `handel`.
- Should read `configured` rather than `configuered`.
- Should read `configured` rather than `configed`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md