### PR TITLE
docs: fix simple typo, prossess -> process

### DIFF
--- a/src/Util.h
+++ b/src/Util.h
@@ -3,7 +3,7 @@
 
 #include "VirtualBox.h"
 
-// Tests whether the current user and prossess has admin privileges.
+// Tests whether the current user and process has admin privileges.
 // Note that this will return FALSE if called from a Vista program running in an administrator account if the process was not launched with 'run as administrator'
 BOOL isAdmin();
 


### PR DESCRIPTION
There is a small typo in src/Util.h.

Should read `process` rather than `prossess`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md